### PR TITLE
Githubのcontainerにimageをpushするworkflowを追加

### DIFF
--- a/.github/workflows/push-develop-image-to-docker.yml
+++ b/.github/workflows/push-develop-image-to-docker.yml
@@ -1,0 +1,33 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  push_to_registory:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/choco_backend:develop
+            ghcr.io/${{ github.repository_owner }}/choco_backend:${{ github.sha }}


### PR DESCRIPTION
## 関連資料

- Kibera:

## 概要
developにマージされたときに自動でGithub Container Registryにdocker imageをpushするworkflowを記述
<!-- このプルリクエストでやったことをざっくり書く -->

## 確認方法

<!-- レビュアーに確認して欲しい状態の再現方法、対象のURL・ユーザーなど -->
<!-- マイグレーション、Rakeタスクなどを実行する必要があれば書く -->
<!-- 確認して欲しいURLは、curl '対象URL' のように記載する-->

## チェックリスト

- [ ] テストは書いたか
- [ ] ドキュメントの更新は必要か（テーブル定義、API 仕様書など）

## その他

## スクリーンショット
