### PR TITLE
mainブランチにpushされたときにcircleciをapiから実行させる

### DIFF
--- a/.github/workflows/run-circleci-on-main.yml
+++ b/.github/workflows/run-circleci-on-main.yml
@@ -1,0 +1,17 @@
+name: Run CircleCI on main blanch
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-circleci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run CircleCI
+        env:
+          CIRCLECI_BRANCH: ${{ github.head_ref }}
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+        run: |
+          curl -X POST -u "$CIRCLECI_TOKEN:" -H 'Content-Type: application/json' -d "{\"branch\":\"$CIRCLECI_BRANCH\"}" --url "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline"


### PR DESCRIPTION
## 関連資料

- Kibera:

## 概要
CircleCIの設定で`Only Build Pull Request`を指定しているので、PRに関連する時以外はCircleCIが実行されない。
そのため、main branchにmergeされたときにcircleciのbuildが走らないのでそれを可能にする。

<!-- このプルリクエストでやったことをざっくり書く -->

## 確認方法

<!-- レビュアーに確認して欲しい状態の再現方法、対象のURL・ユーザーなど -->
<!-- マイグレーション、Rakeタスクなどを実行する必要があれば書く -->
<!-- 確認して欲しいURLは、curl '対象URL' のように記載する-->

## チェックリスト

- [ ] テストは書いたか
- [ ] ドキュメントの更新は必要か（テーブル定義、API 仕様書など）

## その他

## スクリーンショット
